### PR TITLE
Added argparse library to process command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ python haystack.py <filename>
 ## License
 This project is licensed under the MIT License - see the [LICENSE.md](https://github.com/rjayroso/react-vehicle-database-manager/blob/master/LICENSE) file for details.
 ## Version
-- Release 0.1 - Stable Build
+- Release 0.3 - Stable Build
 ## Contributing
 For those wanting to contribute, please read [CONTRIBUTING.md](https://gist.github.com/PurpleBooth/b24679402957c63ec426) for details.
 ## Acknowledgments

--- a/haystack.py
+++ b/haystack.py
@@ -1,16 +1,17 @@
 # ---- HAYSTACK ----
 # Author: Royce Ayroso-Ong
-# Version: 0.1
+# Version: 0.3
 # Licence: MIT Licence
 # Description: Haystack checks through a file for broken links
 
 
-import sys                      # command line arguments
-import requests                 # url validating
-import codecs                   # file handling
-import re                       # regex for urls
-from termcolor import colored   # colored terminal text
-from multiprocessing.dummy import Pool # Add Feature: add support for parallelization, using multiple CPU cores so your program can do more than one thing at a time
+import argparse                         # parsing command line arguments 
+import sys                              # command line arguments
+import requests                         # url validating
+import codecs                           # file handling
+import re                               # regex for urls
+from termcolor import colored           # colored terminal text
+from multiprocessing.dummy import Pool  # support for parallelization
 
 
 # count variables to record the amount of valid/bad/unknown links
@@ -56,33 +57,42 @@ def check_url(url):
             unknown_urls_count += 1
 
 
+def version():
+    print("Haystack Version 0.3")
+
+
+def main(file):
+    try:  # read from file
+        file = codecs.open(file, 'r', 'utf-8')
+    except OSError as err:  # error opening file
+        print("Error opening file: {0}".format(err))
+    else:  # success opening file
+        urls = find_urls(file.read())
+        pool = Pool(10)              # Using 5 Thread pool
+        pool.map(check_url, urls)    # Return an iterator that applies function to every item of iterable, yielding the results
+        pool.close()
+        pool.join()
+
+        # Using '+' operator to connect with each sentence to print
+        print("Haystack has finished processing the file.\n" + colored("# of VALID links: {} | ".format(valid_urls_count), 'green') + colored("# of UNKNOWN links: {} | ".format(unknown_urls_count), 'yellow') + colored("# of BAD links: {}".format(bad_urls_count), 'red'))
+
+
 if __name__ == '__main__':
-    if len(sys.argv) > 2:
-        print("Error: too many command arguments")
+    parser = argparse.ArgumentParser(
+        description="These are common Haystack commands used in various situations:",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument('-v', '--version', help="display installed version", action="store_true")
+    parser.add_argument('-f', '--file',  help="search through a file for broken links", dest="file")
+    args = parser.parse_args()
 
-    elif len(sys.argv) == 1 or sys.argv[1] == '-h' or sys.argv[1] == '--help':  # -h|--help argument to display help
-        print('usage: python haystack.py [-v | --version] [-h | --help] [<filename>]')
-        print('\nThese are common Haystack commands used in various situations:')
-        print('    {:<30}{}'.format('-v, --version', 'Show current version'))
-        print('    {:<30}{}'.format('-h, --help', 'Show commands and how to use them'))
+    if args.version:
+        version()
 
-    elif sys.argv[1] == '-v' or sys.argv[1] == '--version':  # -v|--version argument to display the version
-        print("Haystack Version 0.1")
-
-    elif len(sys.argv) == 2:  # file name argument
-        try:  # read from file
-            file = codecs.open(sys.argv[1], 'r', 'utf-8')
-        except OSError as err:  # error opening file
-            print("Error opening file: {0}".format(err))
-        else:  # success opening file
-            urls = find_urls(file.read())
-            pool = Pool(10)              # Using 5 Thread pool
-            pool.map(check_url, urls)    # Return an iterator that applies function to every item of iterable, yielding the results
-            pool.close()
-            pool.join()
-
-            # Using '+' operator to connect with each sentence to print
-            print("Haystack has finished processing the file.\n" + colored("# of VALID links: {} | ".format(valid_urls_count), 'green') + colored("# of UNKNOWN links: {} | ".format(unknown_urls_count), 'yellow') + colored("# of BAD links: {}".format(bad_urls_count), 'red'))
+    elif args.file:
+        main(args.file)
 
     else:
-        print("Error: unknown commands")
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+        


### PR DESCRIPTION
This is a fix for issue #10. 
[x] Added argparse library
[x] Changed the way you process your command line argument, argparse now handles them
[x] Displays the print_help(sys.stderr) when no argument is passed.
[x] Update the version number in your README.md

Fixes #10 