### PR TITLE
Added support for additional flags

### DIFF
--- a/haystack.py
+++ b/haystack.py
@@ -60,10 +60,6 @@ def check_url(url):
             unknown_urls_count += 1
 
 
-def version():
-    print("Haystack Version 0.3")
-
-
 def main(file):
     try:  # read from file
         file = codecs.open(file, 'r', 'utf-8')
@@ -72,25 +68,29 @@ def main(file):
     else:  # success opening file
         urls = find_urls(file.read())
         pool = Pool(10)              # Using 5 Thread pool
-        pool.map(check_url, urls)    # Return an iterator that applies function to every item of iterable, yielding the results
+        pool.map(check_url, urls)    # Returns an iterator that applies function to every item of iterable
         pool.close()
         pool.join()
 
         # Using '+' operator to connect with each sentence to print
-        print("Haystack has finished processing the file.\n" + colored("# of VALID links: {} | ".format(valid_urls_count), 'green') + colored("# of UNKNOWN links: {} | ".format(unknown_urls_count), 'yellow') + colored("# of BAD links: {}".format(bad_urls_count), 'red'))
+        print("Haystack has finished processing the file.\n" +
+              colored("# of VALID links: {} | ".format(valid_urls_count), 'green') +
+              colored("# of UNKNOWN links: {} | ".format(unknown_urls_count), 'yellow') +
+              colored("# of BAD links: {}".format(bad_urls_count), 'red'))
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="These are common Haystack commands used in various situations:",
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('-v', '--version', help="display installed version", action="store_true")
-    parser.add_argument('-f', '--file',  help="search through a file for broken links", dest="file")
+    parser = argparse.ArgumentParser(description='These are common Haystack commands used in various situations:')
+    parser.add_argument('-v', '--version',
+                        action="version",
+                        help="display installed version",
+                        version='%(prog)s version 3.0')
+    parser.add_argument('-f', '--file',
+                        help="search through a file for broken links",
+                        dest="file")
     args = parser.parse_args()
 
-    if args.version:
-        version()
-
-    elif args.file:
+    if args.file:
         main(args.file)
 
     else:

--- a/haystack.py
+++ b/haystack.py
@@ -4,6 +4,7 @@
 # Licence: MIT Licence
 # Description: Haystack checks through a file for broken links
 
+# TODO: add vertical white space, finish flag parsing functionality
 
 import argparse                         # parsing command line arguments 
 import sys                              # command line arguments
@@ -31,36 +32,29 @@ def check_url(url):
     global valid_urls_count
     global bad_urls_count
     global unknown_urls_count
-
     try:  # get status code
         request = requests.head(url, timeout=3)
         status = request.status_code
-
     except KeyboardInterrupt:  # must include to be able to stop the program while it is running
         sys.exit()
-
     except:
         print(colored("Unknown link: {}".format(url), 'yellow'))
         unknown_urls_count += 1
-
     else:
         if status in range(200,299):
             print(colored("Valid link ({}): {}".format(status, url), 'green'))
             valid_urls_count += 1
-
         elif status in range(400,599):
             print(colored("Bad link ({}): {}".format(status, url), 'red'))
             bad_urls_count += 1
-
         elif status in range(300,399):
             print(colored("Redirected link ({}): {}".format(status, url), 'green'))
-
         else:
             print(colored("Unknown link: {}".format(url), 'yellow'))
             unknown_urls_count += 1
 
 
-def main(file):
+def main(file, flag):
     try:  # read from file
         file = codecs.open(file, 'r', 'utf-8')
     except OSError as err:  # error opening file
@@ -71,7 +65,6 @@ def main(file):
         pool.map(check_url, urls)    # Returns an iterator that applies function to every item of iterable
         pool.close()
         pool.join()
-
         # Using '+' operator to connect with each sentence to print
         print("Haystack has finished processing the file.\n" +
               colored("# of VALID links: {} | ".format(valid_urls_count), 'green') +
@@ -80,19 +73,20 @@ def main(file):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='These are common Haystack commands used in various situations:')
-    parser.add_argument('-v', '--version',
-                        action="version",
-                        help="display installed version",
+    parser = argparse.ArgumentParser(prog="Haystack",
+                                     description='These are common Haystack commands used in various situations:')
+    parser.add_argument('-v', '--version', action='version', help='display installed version',
                         version='%(prog)s version 3.0')
-    parser.add_argument('-f', '--file',
-                        help="search through a file for broken links",
-                        dest="file")
+    parser.add_argument('-f', '--file', help='search through a file for broken links',  dest='file')
+    # optional flags for file processing, default is --all, only one flag can be present at a time
+    flag_group = parser.add_mutually_exclusive_group()
+    flag_group.add_argument('--all', help='displays all links', action='store_const', const='--all', default='--all',
+                            dest='flag')
+    flag_group.add_argument('--good', help='displays good links', action='store_const', const='--good', dest='flag')
+    flag_group.add_argument('--bad', help='displays bad links', action='store_const', const='--bad', dest='flag')
     args = parser.parse_args()
-
     if args.file:
-        main(args.file)
-
+        main(args.file, args.flag)
     else:
         parser.print_help(sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
Closes #13 
Now supports --all, --good, and --bad flags. 
The --all flag is the default, and if none of these are present, it will display good and bad URLs. 
The --good flag causes only good URLs to get displayed; the --bad flag causes only bad URLs to get displayed.